### PR TITLE
SDI-333 Changes to event handling to improve latency

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
@@ -29,6 +29,7 @@ class JMSConfiguration(
       this.destinationName = queueName
       this.isSessionTransacted = transacted
       this.connectionFactory = connectionFactory
+      this.cacheLevel = DefaultMessageListenerContainer.CACHE_SESSION
 
       val manager = DataSourceTransactionManager()
       manager.dataSource = dataSource

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/OracleAQConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/OracleAQConfiguration.kt
@@ -32,7 +32,8 @@ class OracleAQConfiguration {
     ds.setPassword(password)
     ds.url = connectionstring
     ds.implicitCachingEnabled = true
-    ds.fastConnectionFailoverEnabled = true
+    // Do not reconnect from scratch for each poll:
+    ds.connectionCachingEnabled = true
     return ds
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/JMSReceiver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/JMSReceiver.kt
@@ -15,8 +15,6 @@ class JMSReceiver(
 ) : MessageListener {
 
   override fun onMessage(message: Message) {
-    log.info("JMS AQ Message received: $message")
-
     xtagEventsService.addAdditionalEventData(
       offenderEventsTransformer.offenderEventOf(
         message as AQjmsMapMessage


### PR DESCRIPTION
Improve performance by caching oracle connection and JMS session

Service was barely keeping up with the message volume. Trying to eliminate need to reconnect on each 1s poll