### PR TITLE
SDI-640 Throw a Java Unchecked exception to force a rollback

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitter.kt
@@ -51,7 +51,7 @@ class PrisonEventsEmitter(
         // Exception traceback will be logged by DefaultMessageListenerContainer
         log.error("Failed to publish message $payload", e.cause)
         telemetryClient.trackEvent("${payload.eventType}_FAILED", asTelemetryMap(payload), null)
-        throw RuntimeException(e)
+        throw e
       }
     } catch (e: Exception) {
       log.error("Failed to publish (unexpected exception) message $payload", e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitter.kt
@@ -51,7 +51,7 @@ class PrisonEventsEmitter(
         // Exception traceback will be logged by DefaultMessageListenerContainer
         log.error("Failed to publish message $payload", e.cause)
         telemetryClient.trackEvent("${payload.eventType}_FAILED", asTelemetryMap(payload), null)
-        throw e
+        throw RuntimeException(e)
       }
     } catch (e: Exception) {
       log.error("Failed to publish (unexpected exception) message $payload", e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitter.kt
@@ -51,12 +51,12 @@ class PrisonEventsEmitter(
         // Exception traceback will be logged by DefaultMessageListenerContainer
         log.error("Failed to publish message $payload", e.cause)
         telemetryClient.trackEvent("${payload.eventType}_FAILED", asTelemetryMap(payload), null)
-        throw e
+        throw RuntimeException(e)
       }
     } catch (e: Exception) {
       log.error("Failed to publish (unexpected exception) message $payload", e)
       telemetryClient.trackEvent("${payload.eventType}_FAILED", asTelemetryMap(payload), null)
-      throw e
+      throw RuntimeException(e)
     }
     val httpStatusCode = publishResult.sdkHttpResponse().statusCode()
     if (httpStatusCode >= 400) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
+import java.net.SocketException
 import java.time.Duration
 
 class OracleToTopicIntTest : IntegrationTestBase() {
@@ -174,7 +175,7 @@ class OracleToTopicIntTest : IntegrationTestBase() {
   }
 
   private fun sabotageTopic() {
-    doThrow(RuntimeException("Test exception")).whenever(snsClient).publish(any<PublishRequest>())
+    doThrow(SocketException("Test exception")).whenever(snsClient).publish(any<PublishRequest>())
   }
 
   private fun fixTopic() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doCallRealMethod
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mockingDetails
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy
@@ -19,6 +20,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.jms.core.JmsTemplate
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sns.model.PublishResponse
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.prisonerevents.config.FULL_QUEUE_NAME
@@ -175,7 +177,8 @@ class OracleToTopicIntTest : IntegrationTestBase() {
   }
 
   private fun sabotageTopic() {
-    whenever(snsClient.publish(any<PublishRequest>())).thenReturn(CompletableFuture.failedFuture(SocketException("Test exception")))
+    doReturn(CompletableFuture.failedFuture<PublishResponse>(SocketException("Test exception"))).whenever(snsClient)
+      .publish(any<PublishRequest>())
   }
 
   private fun fixTopic() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.hmpps.sqs.HmppsTopic
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.net.SocketException
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
 
 class OracleToTopicIntTest : IntegrationTestBase() {
 
@@ -175,7 +176,7 @@ class OracleToTopicIntTest : IntegrationTestBase() {
   }
 
   private fun sabotageTopic() {
-    doThrow(SocketException("Test exception")).whenever(snsClient).publish(any<PublishRequest>())
+    whenever(snsClient.publish(any<PublishRequest>())).thenReturn(CompletableFuture.failedFuture(SocketException("Test exception")))
   }
 
   private fun fixTopic() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doCallRealMethod
-import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mockingDetails
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/PrisonEventsEmitterTest.kt
@@ -239,7 +239,7 @@ class PrisonEventsEmitterTest {
           bookingId = 12345L,
         ),
       )
-    }.cause().isInstanceOf(RuntimeException::class.java)
+    }.rootCause().isInstanceOf(RuntimeException::class.java)
       .message()
       .isEqualTo("test")
 


### PR DESCRIPTION
JMS Container has the following code 
`
try {
				messageReceived = doReceiveAndExecute(invoker, session, consumer, status);
			}
			catch (JMSException | RuntimeException | Error ex) {
				rollbackOnException(this.transactionManager, status, ex);
				throw ex;
			}
`
so rollback doesn't seem to happen for checked exceptions - so convert all exceptions to Runtime exceptions