### PR TITLE
SDIT-1860 Stop transforming COURT_EVENT_CHARGES-UPDATED

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
@@ -195,7 +195,7 @@ class OffenderEventsTransformer {
           xtag,
         )
 
-        "COURT_EVENT_CHARGES-UPDATED", "COURT_EVENT_CHARGES-INSERTED", "COURT_EVENT_CHARGES-DELETED" -> courtEventChargeEventOf(
+        "COURT_EVENT_CHARGES-INSERTED", "COURT_EVENT_CHARGES-DELETED" -> courtEventChargeEventOf(
           xtag,
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
@@ -2845,11 +2845,6 @@ class OffenderEventsTransformerTest {
   }
 
   @Test
-  fun `court event charge update event mapped correctly`() {
-    courtEventChargeEventMappedCorrectly("COURT_EVENT_CHARGES-UPDATED")
-  }
-
-  @Test
   fun `court event charge inserted event mapped correctly`() {
     courtEventChargeEventMappedCorrectly("COURT_EVENT_CHARGES-INSERTED")
   }


### PR DESCRIPTION
COURT_EVENT_CHARGES-UPDATED is to be removed by NOMIS - since OFFENDER_CHARGES-UPDATED will always be fired if there is a significant change