### PR TITLE
SDIT-1820 Configure concurrentConsumers and add telemetry span for listener

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   implementation("com.oracle.database.messaging:aqapi-jakarta:23.3.1.0")
 
   implementation("org.apache.commons:commons-lang3:3.14.0")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.4.0")
 
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.0.2-beta-3")
   testImplementation("org.awaitility:awaitility-kotlin:4.2.1")

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    JMS_CONNECTION_CONCURRENTCONSUMERS: 1
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerevents.config
 import jakarta.jms.ConnectionFactory
 import jakarta.jms.ExceptionListener
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.jms.connection.JmsTransactionManager
@@ -32,11 +33,13 @@ class JMSConfiguration {
     listenerConnectionFactory: ConnectionFactory,
     dataSource: DataSource,
     jmsReceiver: JMSReceiver,
+    @Value("\${jms.connection.concurrentConsumers:1}") concurrentConsumers: Int,
   ): DefaultMessageListenerContainer =
     DefaultMessageListenerContainer().apply {
       this.destinationName = FULL_QUEUE_NAME
       this.connectionFactory = listenerConnectionFactory
       this.cacheLevel = DefaultMessageListenerContainer.CACHE_SESSION
+      this.concurrentConsumers = concurrentConsumers
       this.exceptionListener = ExceptionListener {
         log.error("DefaultMessageListenerContainer exceptionListener detected error:", it)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/JMSReceiver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/JMSReceiver.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonerevents.service
 
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import jakarta.jms.Message
 import jakarta.jms.MessageListener
 import oracle.jakarta.jms.AQjmsMapMessage
@@ -14,6 +16,7 @@ class JMSReceiver(
   private val eventsEmitter: PrisonEventsEmitter,
 ) : MessageListener {
 
+  @WithSpan(value = "nomis-XTAG_DPS-queue", kind = SpanKind.SERVER)
   override fun onMessage(message: Message) {
     xtagEventsService.addAdditionalEventData(
       offenderEventsTransformer.offenderEventOf(


### PR DESCRIPTION
Initially this is an experiment to check if concurrency works with AQJMS so set to default of 1