### PR TITLE
SDIT-1820 Configure maxConcurrentConsumers

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,8 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-    JMS_CONNECTION_CONCURRENTCONSUMERS: 1
+    JMS_CONNECTION_CONCURRENTCONSUMERS: 10
+    JMS_CONNECTION_MAXCONCURRENTCONSUMERS: 20
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,7 +1,7 @@
 # Per environment values which override defaults in hmpps-prisoner-events/values.yaml
 
 generic-service:
-  replicaCount: 2
+  replicaCount: 4
 
   ingress:
     host: prisoner-events-preprod.prison.service.justice.gov.uk
@@ -14,6 +14,8 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    JMS_CONNECTION_CONCURRENTCONSUMERS: 10
+    JMS_CONNECTION_MAXCONCURRENTCONSUMERS: 20
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,3 +8,5 @@ generic-service:
 
   env:
     API_BASE_URL_HMPPS_AUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
+    JMS_CONNECTION_CONCURRENTCONSUMERS: 1
+    JMS_CONNECTION_MAXCONCURRENTCONSUMERS: 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
@@ -34,11 +34,13 @@ class JMSConfiguration {
     dataSource: DataSource,
     jmsReceiver: JMSReceiver,
     @Value("\${jms.connection.concurrentConsumers:1}") concurrentConsumers: Int,
+    @Value("\${jms.connection.maxConcurrentConsumers:1}") maxConcurrentConsumers: Int,
   ): DefaultMessageListenerContainer =
     DefaultMessageListenerContainer().apply {
       this.destinationName = FULL_QUEUE_NAME
       this.connectionFactory = listenerConnectionFactory
       this.cacheLevel = DefaultMessageListenerContainer.CACHE_SESSION
+      this.maxConcurrentConsumers = maxConcurrentConsumers
       this.concurrentConsumers = concurrentConsumers
       this.exceptionListener = ExceptionListener {
         log.error("DefaultMessageListenerContainer exceptionListener detected error:", it)


### PR DESCRIPTION
So preprod will now have 4 pods - default of 10 listeners so 40 in total that can scale up to 80

Keep prod as 1 until we confirm this all works