### PR TITLE
SDIT-1820 Revert concurrent consumers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
   implementation("com.oracle.database.messaging:aqapi-jakarta:23.3.1.0")
 
   implementation("org.apache.commons:commons-lang3:3.14.0")
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.4.0")
 
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.0.2-beta-3")
   testImplementation("org.awaitility:awaitility-kotlin:4.2.1")

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,8 +14,6 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-    JMS_CONNECTION_CONCURRENTCONSUMERS: 10
-    JMS_CONNECTION_MAXCONCURRENTCONSUMERS: 20
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,8 +14,6 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
-    JMS_CONNECTION_CONCURRENTCONSUMERS: 10
-    JMS_CONNECTION_MAXCONCURRENTCONSUMERS: 20
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,5 +8,3 @@ generic-service:
 
   env:
     API_BASE_URL_HMPPS_AUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
-    JMS_CONNECTION_CONCURRENTCONSUMERS: 1
-    JMS_CONNECTION_MAXCONCURRENTCONSUMERS: 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.prisonerevents.config
 import jakarta.jms.ConnectionFactory
 import jakarta.jms.ExceptionListener
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.jms.connection.JmsTransactionManager
@@ -33,15 +32,11 @@ class JMSConfiguration {
     listenerConnectionFactory: ConnectionFactory,
     dataSource: DataSource,
     jmsReceiver: JMSReceiver,
-    @Value("\${jms.connection.concurrentConsumers:1}") concurrentConsumers: Int,
-    @Value("\${jms.connection.maxConcurrentConsumers:1}") maxConcurrentConsumers: Int,
   ): DefaultMessageListenerContainer =
     DefaultMessageListenerContainer().apply {
       this.destinationName = FULL_QUEUE_NAME
       this.connectionFactory = listenerConnectionFactory
       this.cacheLevel = DefaultMessageListenerContainer.CACHE_SESSION
-      this.maxConcurrentConsumers = maxConcurrentConsumers
-      this.concurrentConsumers = concurrentConsumers
       this.exceptionListener = ExceptionListener {
         log.error("DefaultMessageListenerContainer exceptionListener detected error:", it)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/JMSReceiver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/JMSReceiver.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.prisonerevents.service
 
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.instrumentation.annotations.WithSpan
 import jakarta.jms.Message
 import jakarta.jms.MessageListener
 import oracle.jakarta.jms.AQjmsMapMessage
@@ -16,7 +14,6 @@ class JMSReceiver(
   private val eventsEmitter: PrisonEventsEmitter,
 ) : MessageListener {
 
-  @WithSpan(value = "nomis-XTAG_DPS-queue", kind = SpanKind.SERVER)
   override fun onMessage(message: Message) {
     xtagEventsService.addAdditionalEventData(
       offenderEventsTransformer.offenderEventOf(


### PR DESCRIPTION
The number of SQL dependencies in App Insights has increased dramatically since we introduced concurent consumers. Reverting concurrent consumers to see if it has any effect on the problems we're seeing with the shared pool running out of memory in NOMIS.
![image](https://github.com/user-attachments/assets/d0802053-2c3a-49db-b51b-2af02187dfa3)
