### PR TITLE
SDIT-1820 Remove transaction manager for listener

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/config/JMSConfiguration.kt
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.jms.connection.JmsTransactionManager
 import org.springframework.jms.core.JmsTemplate
 import org.springframework.jms.listener.DefaultMessageListenerContainer
 import org.springframework.jms.support.destination.JmsDestinationAccessor
@@ -51,11 +50,6 @@ class JMSConfiguration {
         log.error("DefaultMessageListenerContainer errorHandler detected error:", it)
       }
       this.isSessionTransacted = true
-
-      val manager = JmsTransactionManager()
-      manager.connectionFactory = listenerConnectionFactory
-
-      this.setTransactionManager(manager)
 
       this.messageListener = jmsReceiver
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,7 +44,7 @@ hmpps:
       prisoneventtestqueue:
         queueName: ${random.uuid}
         subscribeTopicId: prisoneventtopic
-        subscribeFilter: '{"eventType":[ "OFFENDER_MOVEMENT-RECEPTION", "OFFENDER_MOVEMENT-DISCHARGE", "PRISONER_ACTIVITY-UPDATE", "PRISONER_APPOINTMENT-UPDATE" ] }'
+        subscribeFilter: '{"eventType":[ "OFFENDER_MOVEMENT-RECEPTION", "OFFENDER_MOVEMENT-DISCHARGE", "PRISONER_ACTIVITY-UPDATE", "PRISONER_APPOINTMENT-UPDATE", "AGY_INT_LOC_PROFILES-UPDATED" ] }'
     topics:
       prisoneventtopic:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}


### PR DESCRIPTION
According to https://docs.spring.io/spring-framework/reference/integration/jms/receiving.html a transaction manager is only required for XA transactions. The TM being used will create a new connection for each message and each poll causing performance issues with Oracle.