### PR TITLE
SDIT-1082 Prep work before distinguishing between merge and book number change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/model/OffenderEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/model/OffenderEvent.kt
@@ -631,6 +631,33 @@ class OffenderContactEvent(
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+class OffenderBookingNumberChangeOrMergeEvent(
+  eventType: String,
+  nomisEventType: String,
+  eventDatetime: LocalDateTime,
+  offenderIdDisplay: String? = null,
+  previousOffenderIdDisplay: String? = null,
+  bookingId: Long,
+  offenderId: Long?,
+  val bookingNumber: String? = null,
+  val previousBookingNumber: String? = null,
+  val type: BookingNumberChangedType = BookingNumberChangedType.BOOK_NUMBER_CHANGE,
+) : OffenderEvent(
+  eventType = eventType,
+  eventDatetime = eventDatetime,
+  nomisEventType = nomisEventType,
+  offenderIdDisplay = offenderIdDisplay,
+  bookingId = bookingId,
+  offenderId = offenderId,
+)
+
+enum class BookingNumberChangedType {
+  MERGE,
+  BOOK_NUMBER_CHANGE,
+  DUPLICATE,
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class GenericOffenderEvent(
   eventType: String? = null,
   eventDatetime: LocalDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.prisonerevents.model.ExternalMovementOffende
 import uk.gov.justice.digital.hmpps.prisonerevents.model.GenericOffenderEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.IWPDocumentOffenderEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.NonAssociationDetailsOffenderEvent
+import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderBookingNumberChangeOrMergeEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderBookingReassignedEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderChargeEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderContactEvent
@@ -919,15 +920,14 @@ class OffenderEventsTransformer {
     nomisEventType = xtag.eventType,
   )
 
-  private fun bookingNumberEventOf(xtag: Xtag) = GenericOffenderEvent(
+  private fun bookingNumberEventOf(xtag: Xtag) = OffenderBookingNumberChangeOrMergeEvent(
     eventType = "BOOKING_NUMBER-CHANGED",
-    eventDatetime = xtag.nomisTimestamp,
+    eventDatetime = xtag.nomisTimestamp!!,
     offenderId = xtag.content.p_offender_id?.toLong(),
-    bookingId = xtag.content.p_offender_book_id?.toLong(),
+    bookingId = xtag.content.p_offender_book_id!!.toLong(),
     bookingNumber = xtag.content.p_new_prison_num,
-    previousBookingNumber =
-    xtag.content.p_old_prison_num ?: xtag.content.p_old_prision_num ?: xtag.content.p_old_prison_number,
-    nomisEventType = xtag.eventType,
+    previousBookingNumber = xtag.content.p_old_prison_num,
+    nomisEventType = xtag.eventType!!,
   )
 
   private fun confirmedReleaseDateOf(xtag: Xtag) = GenericOffenderEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.prisonerevents.model.ExternalMovementOffende
 import uk.gov.justice.digital.hmpps.prisonerevents.model.GenericOffenderEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.IWPDocumentOffenderEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.NonAssociationDetailsOffenderEvent
+import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderBookingNumberChangeOrMergeEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderBookingReassignedEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderChargeEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderContactEvent
@@ -887,7 +888,7 @@ class OffenderEventsTransformerTest {
   @Test
   fun `booking number P1_RESULT mapped correctly`() {
     val now = LocalDateTime.now()
-    withCallTransformer<GenericOffenderEvent>(
+    withCallTransformer<OffenderBookingNumberChangeOrMergeEvent>(
       Xtag(
         eventType = "P1_RESULT",
         nomisTimestamp = now,
@@ -914,7 +915,7 @@ class OffenderEventsTransformerTest {
   @Test
   fun `booking number mapped correctly`() {
     val now = LocalDateTime.now()
-    withCallTransformer<GenericOffenderEvent>(
+    withCallTransformer<OffenderBookingNumberChangeOrMergeEvent>(
       Xtag(
         eventType = "BOOK_UPD_OASYS",
         nomisTimestamp = now,
@@ -922,7 +923,6 @@ class OffenderEventsTransformerTest {
           mapOf(
             "p_offender_book_id" to "434",
             "p_offender_id" to "987",
-            "p_new_prison_num" to "Y123CD",
             "p_old_prison_num" to "Y123AB",
           ),
         ),
@@ -931,7 +931,7 @@ class OffenderEventsTransformerTest {
       assertThat(eventType).isEqualTo("BOOKING_NUMBER-CHANGED")
       assertThat(bookingId).isEqualTo(434L)
       assertThat(offenderId).isEqualTo(987)
-      assertThat(bookingNumber).isEqualTo("Y123CD")
+      assertThat(bookingNumber).isNull()
       assertThat(previousBookingNumber).isEqualTo("Y123AB")
       assertThat(offenderIdDisplay).isNull()
       assertThat(nomisEventType).isEqualTo("BOOK_UPD_OASYS")


### PR DESCRIPTION
Currently a book number change (via the data correction page) is treated the same as a prisoner merge even though these 2 "events" are completely different. 
This is stage 1/3 of untangling this so clients no the differences and act accordingly.
This initial work established what the interface to the event will look like.