### PR TITLE
SDIT-1082 BOOKING_NUMBER-CHANGED now indicates if a merge or not

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/model/OffenderEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/model/OffenderEvent.kt
@@ -636,12 +636,12 @@ class OffenderBookingNumberChangeOrMergeEvent(
   nomisEventType: String,
   eventDatetime: LocalDateTime,
   offenderIdDisplay: String? = null,
-  previousOffenderIdDisplay: String? = null,
+  var previousOffenderIdDisplay: String? = null,
   bookingId: Long,
   offenderId: Long?,
   val bookingNumber: String? = null,
-  val previousBookingNumber: String? = null,
-  val type: BookingNumberChangedType = BookingNumberChangedType.BOOK_NUMBER_CHANGE,
+  var previousBookingNumber: String? = null,
+  var type: BookingNumberChangedType = BookingNumberChangedType.BOOK_NUMBER_CHANGE,
 ) : OffenderEvent(
   eventType = eventType,
   eventDatetime = eventDatetime,
@@ -654,7 +654,7 @@ class OffenderBookingNumberChangeOrMergeEvent(
 enum class BookingNumberChangedType {
   MERGE,
   BOOK_NUMBER_CHANGE,
-  DUPLICATE,
+  BOOK_NUMBER_CHANGE_DUPLICATE,
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/ExposeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/ExposeRepository.kt
@@ -25,7 +25,7 @@ class ExposeRepository {
 
   fun findRelatedMerge(bookingId: Long, eventDatetime: LocalDateTime): MergeTransaction? =
     MergeTransaction.find {
-      (MergeTransactions.bookingId2 eq bookingId) and (MergeTransactions.requestDate greater eventDatetime.minusHours(1))
+      (MergeTransactions.bookingId2 eq bookingId) and (MergeTransactions.requestDate greater eventDatetime.minusHours(2))
     }
       .orderBy(MergeTransactions.createDatetime to SortOrder.DESC)
       .firstOrNull()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/ExposeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/ExposeRepository.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.prisonerevents.repository
 
 import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class ExposeRepository {
@@ -19,4 +22,11 @@ class ExposeRepository {
       .where(OffenderContactPersons.id eq contactId)
       .singleOrNull()
       ?.get(Offenders.offenderNo)
+
+  fun findRelatedMerge(bookingId: Long, eventDatetime: LocalDateTime): MergeTransaction? =
+    MergeTransaction.find {
+      (MergeTransactions.bookingId2 eq bookingId) and (MergeTransactions.requestDate greater eventDatetime.minusHours(1))
+    }
+      .orderBy(MergeTransactions.createDatetime to SortOrder.DESC)
+      .firstOrNull()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/XtagEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/XtagEventsService.kt
@@ -78,12 +78,12 @@ class XtagEventsService(
         if (oe.nomisEventType == "P1_RESULT") {
           oe.type = BookingNumberChangedType.BOOK_NUMBER_CHANGE
         } else {
-          // BOOK_UPD_OASYS is for both for a merge and a booking number change
+          // BOOK_UPD_OASYS is fired both for a merge and a booking number change
+          // so look for a very recent merge
           exposeRepository.findRelatedMerge(oe.bookingId!!, oe.eventDatetime!!)?.also {
             oe.type = BookingNumberChangedType.MERGE
             oe.offenderIdDisplay = it.offenderNo2
             oe.previousOffenderIdDisplay = it.offenderNo1
-            oe.type = BookingNumberChangedType.MERGE
           } ?: run {
             oe.type = BookingNumberChangedType.BOOK_NUMBER_CHANGE_DUPLICATE
           }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/XtagEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/XtagEventsService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.prisonerevents.model.OffenderEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.model.PersonRestrictionOffenderEvent
 import uk.gov.justice.digital.hmpps.prisonerevents.repository.ExposeRepository
 import uk.gov.justice.digital.hmpps.prisonerevents.repository.SqlRepository
+import java.time.LocalDateTime
 
 @Service
 class XtagEventsService(
@@ -90,6 +91,7 @@ class XtagEventsService(
         }
       }
     }
+    println("It is currently ${LocalDateTime.now()}")
     return oe
   }
 }


### PR DESCRIPTION
* P1_RESULT is never a merge, always fired for book number change
* BOOK_UPD_OASYS is always fired for a merge
* BOOK_UPD_OASYS is sometimes fired for a book number change

There, if there has been a recent merge assume this has been merge.

Currently, if there was a merge and a book number change within the hour the 2nd BOOKING_NUMBER-CHANGED would incorrectly indicate a merge (essentially as now). Will look if I can get the time window down further