### PR TITLE
SDIT-1082 BOOKING_NUMBER-CHANGED narrow window of looking up merge

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/ExposeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/ExposeRepository.kt
@@ -25,7 +25,7 @@ class ExposeRepository {
 
   fun findRelatedMerge(bookingId: Long, eventDatetime: LocalDateTime): MergeTransaction? =
     MergeTransaction.find {
-      (MergeTransactions.bookingId2 eq bookingId) and (MergeTransactions.requestDate greater eventDatetime.minusHours(2))
+      (MergeTransactions.bookingId2 eq bookingId) and (MergeTransactions.modifyDatetime greater eventDatetime.minusMinutes(10))
     }
       .orderBy(MergeTransactions.createDatetime to SortOrder.DESC)
       .firstOrNull()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,3 +99,5 @@ hmpps.sqs:
     prisoneventtopic:
       asyncClient: true
       propagateTracing: true
+
+aq.timezone.daylightsavings: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
@@ -560,7 +560,8 @@ class OracleToTopicIntTest : IntegrationTestBase() {
         fun setUp() {
           transaction {
             MergeTransaction.build(
-              requestDate = LocalDateTime.now(),
+              requestDate = LocalDateTime.now().minusMinutes(11),
+              modifyDatetime = LocalDateTime.now().minusMinutes(9),
               offenderId1 = 54321,
               offenderNo1 = "A4321TK",
               bookingId1 = 4321,
@@ -611,7 +612,8 @@ class OracleToTopicIntTest : IntegrationTestBase() {
           transaction {
             MergeTransaction.build(
               // with an old merge
-              requestDate = LocalDateTime.now().minusHours(2),
+              requestDate = LocalDateTime.now().minusMinutes(12),
+              modifyDatetime = LocalDateTime.now().minusMinutes(11),
               offenderId1 = 54321,
               offenderNo1 = "A4321TK",
               bookingId1 = 4321,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/XtagEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/XtagEventsListenerTest.kt
@@ -37,7 +37,7 @@ class XtagEventsListenerTest {
   @BeforeEach
   fun setup() {
     service = XtagEventsListener(
-      OffenderEventsTransformer(),
+      OffenderEventsTransformer(aqHasDaylightSavings = false),
       xtagEventsService,
       eventsEmitter,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
@@ -52,7 +52,7 @@ import java.time.LocalTime
 import java.util.UUID
 
 class OffenderEventsTransformerTest {
-  private val offenderEventsTransformer = OffenderEventsTransformer()
+  private val offenderEventsTransformer = OffenderEventsTransformer(aqHasDaylightSavings = false)
   private val fixedEventTime = LocalDateTime.now()
 
   @Suppress("UNCHECKED_CAST")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -52,3 +52,5 @@ hmpps:
     topics:
       prisoneventtopic:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+
+aq.timezone.daylightsavings: true


### PR DESCRIPTION
The merge transaction should be modified more or less when the xtag event is sent to the queue; this reduces the window to just 10 minutes

Also all flag to change mode of how we calculate the JMS message time:

- By default assume AQ is always using GMT+1
- When running tests using system timezone