### PR TITLE
SDIT-2274 Handle null audit module with placeholder

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/model/OffenderEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/model/OffenderEvent.kt
@@ -301,7 +301,7 @@ class PersonRestrictionOffenderEvent(
   val expiryDate: LocalDate?,
   val authorisedById: Long?,
   val enteredById: Long?,
-  val auditModuleName: String?,
+  val auditModuleName: String,
 ) : OffenderEvent(
   eventType = eventType,
   eventDatetime = eventDatetime,
@@ -321,7 +321,7 @@ class VisitorRestrictionOffenderEvent(
   val expiryDate: LocalDate?,
   val visitorRestrictionId: Long?,
   val enteredById: Long?,
-  val auditModuleName: String?,
+  val auditModuleName: String,
 ) : OffenderEvent(
   eventType = eventType,
   eventDatetime = eventDatetime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
@@ -1107,7 +1107,7 @@ class OffenderEventsTransformer(@Value("\${aq.timezone.daylightsavings}") val aq
     expiryDate = localDateOf(xtag.content.p_restriction_expiry_date),
     authorisedById = xtag.content.p_authorized_staff_id?.toLong(),
     enteredById = xtag.content.p_entered_staff_id?.toLong(),
-    auditModuleName = xtag.content.p_audit_module_name,
+    auditModuleName = xtag.content.p_audit_module_name ?: EMPTY_AUDIT_MODULE,
   )
 
   private fun visitorRestrictionEventOf(xtag: Xtag) = VisitorRestrictionOffenderEvent(
@@ -1121,7 +1121,7 @@ class OffenderEventsTransformer(@Value("\${aq.timezone.daylightsavings}") val aq
     expiryDate = localDateOf(xtag.content.p_expiry_date),
     visitorRestrictionId = xtag.content.p_visitor_restriction_id?.toLong(),
     enteredById = xtag.content.p_entered_staff_id?.toLong(),
-    auditModuleName = xtag.content.p_audit_module_name,
+    auditModuleName = xtag.content.p_audit_module_name ?: EMPTY_AUDIT_MODULE,
   )
 
   private fun prisonerActivityUpdateEventOf(xtag: Xtag) = PrisonerActivityUpdateEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
@@ -843,6 +843,31 @@ class OffenderEventsTransformerTest {
   }
 
   @Test
+  fun `restriction person changes with missing audit moduke mapped correctly`() {
+    withCallTransformer<PersonRestrictionOffenderEvent>(
+      Xtag(
+        eventType = "OFF_PERS_RESTRICTS-UPDATED",
+        nomisTimestamp = fixedEventTime,
+        content = XtagContent(
+          mapOf(
+            "p_offender_contact_person_id" to "1234567",
+            "p_offender_person_restrict_id" to "2345678",
+            "p_restriction_type" to "TYPE",
+            "p_restriction_effective_date" to "12-AUG-2022",
+            "p_restriction_expiry_date" to "2023-03-31",
+            "p_authorized_staff_id" to "12345",
+            "p_comment_text" to "comment",
+            "p_entered_staff_id" to "23456",
+          ),
+        ),
+      ),
+    ) {
+      assertThat(eventType).isEqualTo("PERSON_RESTRICTION-UPSERTED")
+      assertThat(auditModuleName).isEqualTo("UNKNOWN")
+    }
+  }
+
+  @Test
   fun `restriction visitor mapped correctly`() {
     withCallTransformer<VisitorRestrictionOffenderEvent>(
       Xtag(
@@ -873,6 +898,31 @@ class OffenderEventsTransformerTest {
       assertThat(visitorRestrictionId).isEqualTo(123456)
       assertThat(enteredById).isEqualTo(23456)
       assertThat(auditModuleName).isEqualTo("OMUVREST")
+    }
+  }
+
+  @Test
+  fun `restriction visitor with missing module is mapped correctly`() {
+    withCallTransformer<VisitorRestrictionOffenderEvent>(
+      Xtag(
+        eventType = "VISITOR_RESTRICTS-UPDATED",
+        nomisTimestamp = fixedEventTime,
+        content = XtagContent(
+          mapOf(
+            "p_offender_id_display" to "A123BC",
+            "p_person_id" to "12345",
+            "p_visit_restriction_type" to "TYPE",
+            "p_effective_date" to "12-AUG-2022",
+            "p_expiry_date" to "2023-03-31",
+            "p_comment_txt" to "comment",
+            "p_visitor_restriction_id" to "123456",
+            "p_entered_staff_id" to "23456",
+          ),
+        ),
+      ),
+    ) {
+      assertThat(eventType).isEqualTo("VISITOR_RESTRICTION-UPSERTED")
+      assertThat(auditModuleName).isEqualTo("UNKNOWN")
     }
   }
 
@@ -3023,6 +3073,7 @@ class OffenderEventsTransformerTest {
     }
   }
 
+  @Suppress("SameParameterValue")
   private fun courtAppearanceEventMappedCorrectlyForNullCase(eventName: String, translatedEventName: String) {
     val now = LocalDateTime.now()
     withCallTransformer<CourtAppearanceEvent>(


### PR DESCRIPTION
Rather than return null a auditModuleName return "UNKNOWN" so listeners don't have to do the null checks.