### PR TITLE
SDIT-2736 Fire OFFENDER_CONTACT-* event even if row has been deleted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/OffenderContactPerson.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/OffenderContactPerson.kt
@@ -14,6 +14,8 @@ class OffenderContactPerson(id: EntityID<Long>) : LongEntity(id) {
   var person by Person optionalReferencedOn OffenderContactPersons.person
   var contactType by OffenderContactPersons.contactType
   var relationshipType by OffenderContactPersons.relationshipType
+  var createUserName by OffenderContactPersons.createUserName
+  var modifyUserName by OffenderContactPersons.modifyUserName
 }
 
 object OffenderContactPersons : IdTable<Long>("OFFENDER_CONTACT_PERSONS") {
@@ -22,4 +24,6 @@ object OffenderContactPersons : IdTable<Long>("OFFENDER_CONTACT_PERSONS") {
   val person = reference("PERSON_ID", Persons).nullable()
   val contactType = varchar("CONTACT_TYPE", 12)
   val relationshipType = varchar("RELATIONSHIP_TYPE", 12)
+  val createUserName = varchar("CREATE_USER_ID", 32)
+  val modifyUserName = varchar("MODIFY_USER_ID", 32).nullable()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/SqlRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/repository/SqlRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prisonerevents.repository
 
+import org.springframework.jdbc.core.ResultSetExtractor
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -61,23 +62,37 @@ class SqlRepository(private val jdbcTemplate: NamedParameterJdbcTemplate) {
     )
   }
 
-  fun getCreatedByUserOffenderContact(offenderContactPersonId: Long): String? = jdbcTemplate.queryForObject(
+  fun getCreatedByUserOffenderContact(offenderContactPersonId: Long): String? = jdbcTemplate.query(
     """
         SELECT CREATE_USER_ID
         FROM OFFENDER_CONTACT_PERSONS
         WHERE OFFENDER_CONTACT_PERSON_ID = :offenderContactPersonId
     """,
     MapSqlParameterSource().addValue("offenderContactPersonId", offenderContactPersonId),
-  ) { resultSet: ResultSet, _: Int -> resultSet.getString("CREATE_USER_ID") }
+    ResultSetExtractor { resultSet: ResultSet ->
+      if (resultSet.next()) {
+        resultSet.getString("CREATE_USER_ID")
+      } else {
+        null
+      }
+    },
+  )
 
-  fun getModifiedByUserOffenderContact(offenderContactPersonId: Long): String? = jdbcTemplate.queryForObject(
+  fun getModifiedByUserOffenderContact(offenderContactPersonId: Long): String? = jdbcTemplate.query(
     """
         SELECT MODIFY_USER_ID
         FROM OFFENDER_CONTACT_PERSONS
         WHERE OFFENDER_CONTACT_PERSON_ID = :offenderContactPersonId
     """,
     MapSqlParameterSource().addValue("offenderContactPersonId", offenderContactPersonId),
-  ) { resultSet: ResultSet, _: Int -> resultSet.getString("MODIFY_USER_ID") }
+    ResultSetExtractor { resultSet: ResultSet ->
+      if (resultSet.next()) {
+        resultSet.getString("MODIFY_USER_ID")
+      } else {
+        null
+      }
+    },
+  )
 
   fun getExceptionMessageIds(
     exceptionQueue: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/builders/OffenderContactPerson.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/builders/OffenderContactPerson.kt
@@ -9,11 +9,15 @@ fun OffenderContactPerson.Companion.build(
   person: Person,
   contactType: String = "S",
   relationshipType: String = "BRO",
+  createUserName: String = "J.SMITH",
+  modifyUserName: String? = null,
   init: OffenderContactPerson.() -> Unit = {},
 ) = OffenderContactPerson.new {
   this.offenderBooking = offenderBooking
   this.person = person
   this.contactType = contactType
   this.relationshipType = relationshipType
+  this.createUserName = createUserName
+  this.modifyUserName = modifyUserName
   init()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/integration/OracleToTopicIntTest.kt
@@ -346,6 +346,240 @@ class OracleToTopicIntTest : IntegrationTestBase() {
     }
 
     @Nested
+    @DisplayName("OFFENDER_CONTACT-INSERTED -> OFFENDER_CONTACT-INSERTED")
+    inner class OffenderContactInserted {
+      private lateinit var prisonerEvent: PrisonerEventMessage
+      private val offenderNo = "A1234AA"
+      private lateinit var person: Person
+      private lateinit var booking: OffenderBooking
+      private lateinit var offenderContactPerson: OffenderContactPerson
+
+      @BeforeEach
+      fun setUp() {
+        transaction {
+          this.addLogger(StdOutSqlLogger)
+          person = Person.build {}
+          Offender.build {
+            offenderNo = this@OffenderContactInserted.offenderNo
+          }.also {
+            booking = OffenderBooking.build(offender = it).also {
+              offenderContactPerson = OffenderContactPerson.build(offenderBooking = it, person = person, createUserName = "M.MARGE")
+            }
+          }
+        }
+      }
+
+      @Nested
+      inner class HappyPath {
+        @BeforeEach
+        fun setUp() {
+          simulateTrigger(
+            nomisEventType = "OFFENDER_CONTACT-INSERTED",
+            "p_offender_contact_person_id" to offenderContactPerson.id.value,
+            "p_person_id" to person.id.value,
+            "p_offender_book_id" to booking.id.value,
+            "p_emergency_contact_flag" to "N",
+            "p_can_be_contacted_flag" to "N",
+            "p_approved_visitor_flag" to "N",
+            "p_aware_of_charges_flag" to "N",
+            "p_active_flag" to "Y",
+            "p_next_of_kin_flag" to "Y",
+            "p_offender_id_display" to offenderNo,
+            "p_relationship_type" to "CA",
+            "p_contact_type" to "O",
+            "p_audit_module_name" to "OCDPERSO",
+          )
+
+          prisonerEvent = awaitMessage()
+        }
+
+        @Test
+        fun `will map to OFFENDER_CONTACT-INSERTED`() {
+          with(prisonerEvent.message) {
+            assertJsonPath("eventType", "OFFENDER_CONTACT-INSERTED")
+            assertJsonPath("nomisEventType", "OFFENDER_CONTACT-INSERTED")
+            assertJsonPath("contactId", "${offenderContactPerson.id.value}")
+            assertJsonPath("personId", "${person.personId.value}")
+            assertJsonPath("bookingId", "${booking.id.value}")
+            assertJsonPath("approvedVisitor", "false")
+            assertJsonPath("offenderIdDisplay", offenderNo)
+            assertJsonPath("username", "M.MARGE")
+            assertJsonPath("auditModuleName", "OCDPERSO")
+          }
+        }
+
+        @Test
+        fun `will map meta data for the event`() {
+          assertThat(prisonerEvent.eventType).isEqualTo("OFFENDER_CONTACT-INSERTED")
+          assertThat(prisonerEvent.publishedAt).isCloseToUtcNow(within(10, ChronoUnit.SECONDS))
+        }
+      }
+
+      @Nested
+      inner class HappyPathRecordDeleted {
+        @BeforeEach
+        fun setUp() {
+          simulateTrigger(
+            nomisEventType = "OFFENDER_CONTACT-INSERTED",
+            "p_offender_contact_person_id" to 999,
+            "p_person_id" to person.id.value,
+            "p_offender_book_id" to booking.id.value,
+            "p_emergency_contact_flag" to "N",
+            "p_can_be_contacted_flag" to "N",
+            "p_approved_visitor_flag" to "N",
+            "p_aware_of_charges_flag" to "N",
+            "p_active_flag" to "Y",
+            "p_next_of_kin_flag" to "Y",
+            "p_offender_id_display" to offenderNo,
+            "p_relationship_type" to "CA",
+            "p_contact_type" to "O",
+            "p_audit_module_name" to "OCDPERSO",
+          )
+
+          prisonerEvent = awaitMessage()
+        }
+
+        @Test
+        fun `will map to OFFENDER_CONTACT-INSERTED even if record has been deleted`() {
+          with(prisonerEvent.message) {
+            assertJsonPath("eventType", "OFFENDER_CONTACT-INSERTED")
+            assertJsonPath("nomisEventType", "OFFENDER_CONTACT-INSERTED")
+            assertJsonPath("contactId", "999")
+            assertJsonPath("personId", "${person.personId.value}")
+            assertJsonPath("bookingId", "${booking.id.value}")
+            assertJsonPath("approvedVisitor", "false")
+            assertJsonPath("offenderIdDisplay", offenderNo)
+            assertDoesNotHaveJsonPath("username")
+            assertJsonPath("auditModuleName", "OCDPERSO")
+          }
+        }
+
+        @Test
+        fun `will map meta data for the event`() {
+          assertThat(prisonerEvent.eventType).isEqualTo("OFFENDER_CONTACT-INSERTED")
+          assertThat(prisonerEvent.publishedAt).isCloseToUtcNow(within(10, ChronoUnit.SECONDS))
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("OFFENDER_CONTACT-UPDATED -> OFFENDER_CONTACT-UPDATED")
+    inner class OffenderContactUpdated {
+      private lateinit var prisonerEvent: PrisonerEventMessage
+      private val offenderNo = "A1234AA"
+      private lateinit var person: Person
+      private lateinit var booking: OffenderBooking
+      private lateinit var offenderContactPerson: OffenderContactPerson
+
+      @BeforeEach
+      fun setUp() {
+        transaction {
+          this.addLogger(StdOutSqlLogger)
+          person = Person.build {}
+          Offender.build {
+            offenderNo = this@OffenderContactUpdated.offenderNo
+          }.also {
+            booking = OffenderBooking.build(offender = it).also {
+              offenderContactPerson = OffenderContactPerson.build(offenderBooking = it, person = person, modifyUserName = "M.MARGE")
+            }
+          }
+        }
+      }
+
+      @Nested
+      inner class HappyPath {
+        @BeforeEach
+        fun setUp() {
+          simulateTrigger(
+            nomisEventType = "OFFENDER_CONTACT-UPDATED",
+            "p_offender_contact_person_id" to offenderContactPerson.id.value,
+            "p_person_id" to person.id.value,
+            "p_offender_book_id" to booking.id.value,
+            "p_emergency_contact_flag" to "N",
+            "p_can_be_contacted_flag" to "N",
+            "p_approved_visitor_flag" to "N",
+            "p_aware_of_charges_flag" to "N",
+            "p_active_flag" to "Y",
+            "p_next_of_kin_flag" to "Y",
+            "p_offender_id_display" to offenderNo,
+            "p_relationship_type" to "CA",
+            "p_contact_type" to "O",
+            "p_audit_module_name" to "OCDPERSO",
+          )
+
+          prisonerEvent = awaitMessage()
+        }
+
+        @Test
+        fun `will map to OFFENDER_CONTACT-UPDATED`() {
+          with(prisonerEvent.message) {
+            assertJsonPath("eventType", "OFFENDER_CONTACT-UPDATED")
+            assertJsonPath("nomisEventType", "OFFENDER_CONTACT-UPDATED")
+            assertJsonPath("contactId", "${offenderContactPerson.id.value}")
+            assertJsonPath("personId", "${person.personId.value}")
+            assertJsonPath("bookingId", "${booking.id.value}")
+            assertJsonPath("approvedVisitor", "false")
+            assertJsonPath("offenderIdDisplay", offenderNo)
+            assertJsonPath("username", "M.MARGE")
+            assertJsonPath("auditModuleName", "OCDPERSO")
+          }
+        }
+
+        @Test
+        fun `will map meta data for the event`() {
+          assertThat(prisonerEvent.eventType).isEqualTo("OFFENDER_CONTACT-UPDATED")
+          assertThat(prisonerEvent.publishedAt).isCloseToUtcNow(within(10, ChronoUnit.SECONDS))
+        }
+      }
+
+      @Nested
+      inner class HappyPathRecordDeleted {
+        @BeforeEach
+        fun setUp() {
+          simulateTrigger(
+            nomisEventType = "OFFENDER_CONTACT-UPDATED",
+            "p_offender_contact_person_id" to 999,
+            "p_person_id" to person.id.value,
+            "p_offender_book_id" to booking.id.value,
+            "p_emergency_contact_flag" to "N",
+            "p_can_be_contacted_flag" to "N",
+            "p_approved_visitor_flag" to "N",
+            "p_aware_of_charges_flag" to "N",
+            "p_active_flag" to "Y",
+            "p_next_of_kin_flag" to "Y",
+            "p_offender_id_display" to offenderNo,
+            "p_relationship_type" to "CA",
+            "p_contact_type" to "O",
+            "p_audit_module_name" to "OCDPERSO",
+          )
+
+          prisonerEvent = awaitMessage()
+        }
+
+        @Test
+        fun `will map to OFFENDER_CONTACT-UPDATED even if record has been deleted`() {
+          with(prisonerEvent.message) {
+            assertJsonPath("eventType", "OFFENDER_CONTACT-UPDATED")
+            assertJsonPath("nomisEventType", "OFFENDER_CONTACT-UPDATED")
+            assertJsonPath("contactId", "999")
+            assertJsonPath("personId", "${person.personId.value}")
+            assertJsonPath("bookingId", "${booking.id.value}")
+            assertJsonPath("approvedVisitor", "false")
+            assertJsonPath("offenderIdDisplay", offenderNo)
+            assertDoesNotHaveJsonPath("username")
+            assertJsonPath("auditModuleName", "OCDPERSO")
+          }
+        }
+
+        @Test
+        fun `will map meta data for the event`() {
+          assertThat(prisonerEvent.eventType).isEqualTo("OFFENDER_CONTACT-UPDATED")
+          assertThat(prisonerEvent.publishedAt).isCloseToUtcNow(within(10, ChronoUnit.SECONDS))
+        }
+      }
+    }
+
+    @Nested
     @DisplayName("OFF_PERS_RESTRICTS-UPDATED -> PERSON_RESTRICTION-DELETED")
     inner class PersonRestrictionDeleted {
       private lateinit var prisonerEvent: PrisonerEventMessage


### PR DESCRIPTION
Previously this would go to DLQ due to row being deleted and lookup failing. On balance firing the event might be less confusing, so we should find a matching delete event