### PR TITLE
SDIT-2713 link case event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
@@ -248,13 +248,13 @@ class OffenderEventsTransformer(@Value("\${aq.timezone.daylightsavings}") val aq
           eventType = "COURT_EVENT_CHARGES-UNLINKED",
         )
 
-        "OFFENDER_CASES-UPDATED" if xtag.content.p_previous_combined_case_id != null && xtag.content.p_previous_combined_case_id != xtag.content.p_combined_case_id -> courtCaseLinkingEventOf(
+        "OFFENDER_CASES-UPDATED" if (xtag.content.p_previous_combined_case_id != null && xtag.content.p_previous_combined_case_id != xtag.content.p_combined_case_id) -> courtCaseLinkingEventOf(
           xtag,
           eventType = "OFFENDER_CASES-UNLINKED",
           combinedCaseId = xtag.content.p_previous_combined_case_id!!.toLong(),
         )
 
-        "OFFENDER_CASES-UPDATED" if xtag.content.p_combined_case_id != null -> courtCaseLinkingEventOf(
+        "OFFENDER_CASES-UPDATED" if (xtag.content.p_combined_case_id != null && xtag.content.p_previous_combined_case_id == null) -> courtCaseLinkingEventOf(
           xtag,
           eventType = "OFFENDER_CASES-LINKED",
           combinedCaseId = xtag.content.p_combined_case_id!!.toLong(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformer.kt
@@ -248,7 +248,7 @@ class OffenderEventsTransformer(@Value("\${aq.timezone.daylightsavings}") val aq
           eventType = "COURT_EVENT_CHARGES-UNLINKED",
         )
 
-        "OFFENDER_CASES-UPDATED" if xtag.content.p_previous_combined_case_id != null -> courtCaseLinkingEventOf(
+        "OFFENDER_CASES-UPDATED" if xtag.content.p_previous_combined_case_id != null && xtag.content.p_previous_combined_case_id != xtag.content.p_combined_case_id -> courtCaseLinkingEventOf(
           xtag,
           eventType = "OFFENDER_CASES-UNLINKED",
           combinedCaseId = xtag.content.p_previous_combined_case_id!!.toLong(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerevents/service/transformers/OffenderEventsTransformerTest.kt
@@ -3159,6 +3159,43 @@ class OffenderEventsTransformerTest {
     }
   }
 
+  @Test
+  fun `court case updated with both combined and previous combined ids is mapped correctly`() {
+    val now = LocalDateTime.now()
+    withCallTransformer<CourtCaseEvent>(
+      Xtag(
+        eventType = "OFFENDER_CASES-UPDATED",
+        nomisTimestamp = now,
+        content = XtagContent(
+          mapOf(
+            "p_case_status" to "A",
+            "p_status_update_staff_id" to "485887",
+            "p_lids_case_number" to "6",
+            "p_combined_case_id" to "23456",
+            "p_previous_combined_case_id" to "23456",
+            "p_begin_date" to "20250501",
+            "p_status_update_date" to "20250501",
+            "p_case_seq" to "7",
+            "p_agy_loc_id" to "ABDSUM",
+            "p_case_type" to "Y",
+            "p_status_update_reason" to "A",
+            "p_offender_id_display" to "A234BC",
+            "p_offender_book_id" to "12345",
+            "p_case_id" to "1604141",
+            "p_audit_module_name" to "OCULCASE",
+          ),
+        ),
+      ),
+    ) {
+      assertThat(eventType).isEqualTo("OFFENDER_CASES-UPDATED")
+      assertThat(nomisEventType).isEqualTo("OFFENDER_CASES-UPDATED")
+      assertThat(offenderIdDisplay).isEqualTo("A234BC")
+      assertThat(bookingId).isEqualTo(12345)
+      assertThat(caseId).isEqualTo(1604141)
+      assertThat(auditModuleName).isEqualTo("OCULCASE")
+    }
+  }
+
   private fun courtCaseEventMappedCorrectly(eventName: String) {
     val now = LocalDateTime.now()
     withCallTransformer<CourtCaseEvent>(


### PR DESCRIPTION
Fixes an issue with a court update is incorrectly interpreted as a unlink event because both the combinedCaseId and previousCombinedCaseId are in the event with the same value